### PR TITLE
Ownheader

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -388,7 +388,7 @@ func encryptStream(key []byte, w io.Writer) (io.Writer, error) {
 // data. The authcode will be written out in fileWriter.close().
 func newEncryptionWriter(w io.Writer, password passwordFn, fw *fileWriter, aesstrength byte) (io.Writer, error) {
 	keysize := aesKeyLen(aesstrength)
-	salt := make([]byte, keysize / 2)
+	salt := make([]byte, keysize/2)
 	_, err := rand.Read(salt[:])
 	if err != nil {
 		return nil, errors.New("zip: unable to generate random salt")
@@ -437,7 +437,8 @@ func (h *FileHeader) writeWinZipExtra() {
 	h.Extra = append(h.Extra, buf[:]...)
 }
 
-func (h *FileHeader) setEncryptionMethod(enc EncryptionMethod) {
+// SetEncryptionMethod sets the encryption method.
+func (h *FileHeader) SetEncryptionMethod(enc EncryptionMethod) {
 	h.encryption = enc
 	switch enc {
 	case AES128Encryption:
@@ -478,6 +479,6 @@ func (w *Writer) Encrypt(name string, password string, enc EncryptionMethod) (io
 		Method: Deflate,
 	}
 	fh.SetPassword(password)
-	fh.setEncryptionMethod(enc)
+	fh.SetEncryptionMethod(enc)
 	return w.CreateHeader(fh)
 }

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -56,7 +56,7 @@ func TestPasswordHelloWorldAes(t *testing.T) {
 	var b bytes.Buffer
 	for _, f := range r.File {
 		if !f.IsEncrypted() {
-			t.Errorf("Expected %s to be encrypted.", f.FileInfo().Name)
+			t.Errorf("Expected %s to be encrypted.", f.FileInfo().Name())
 		}
 		f.SetPassword("golang")
 		rc, err := f.Open()


### PR DESCRIPTION
Exports SetEncryptionMethod.
Using own headers may be useful when using UTF-8 file names:

    fh := &zip.FileHeader{
            Name:   "test öäü.jpg",
            Method: zip.Deflate,
            Flags:  0x800,
    }
    fh.SetPassword("test")
    fh.SetEncryptionMethod(zip.AES256Encryption)
    w, err := z.w.CreateHeader(fh)
    if err != nil {
            panic(err)
    }
    .....

