### PR TITLE
Let the modified date/time be settable when writing a zip file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Go dependencies
+vendor/
+Gopkg.toml
+Gopkg.lock


### PR DESCRIPTION
There was no modified date/time set when encrypting a file in an archive... So I added a way to set time.Now() as the default one or specify it.
The current code already writes a date as UTC... I think that local time would be a better choice but I didn't change this part.